### PR TITLE
Rewritten seems to stop on ignored event

### DIFF
--- a/src/rewriters/rewritten.rs
+++ b/src/rewriters/rewritten.rs
@@ -44,16 +44,16 @@ where
     type Item = Event<'src>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        // we're still working through items buffered by the rewriter
-        if let Some(ev) = self.writer.buffer.pop_front() {
-            return Some(ev);
+        loop {
+            // we're still working through items buffered by the rewriter
+            if let Some(ev) = self.writer.buffer.pop_front() {
+                return Some(ev);
+            }
+
+            // we need to pop another event and process it
+            let event = self.events.next()?;
+            self.rewriter.rewrite_event(event, &mut self.writer);
         }
-
-        // we need to pop another event and process it
-        let event = self.events.next()?;
-        self.rewriter.rewrite_event(event, &mut self.writer);
-
-        self.writer.buffer.pop_front()
     }
 }
 

--- a/src/rewriters/rewritten.rs
+++ b/src/rewriters/rewritten.rs
@@ -56,3 +56,38 @@ where
         self.writer.buffer.pop_front()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use pulldown_cmark::Tag;
+
+    #[test]
+    fn ignore_some_events() {
+        let events = vec![
+            Event::Start(Tag::Paragraph),
+            Event::Text("This is some text.".into()),
+            Event::Start(Tag::Heading(2)),
+            Event::Text("This is some more text.".into()),
+        ];
+
+        let rewritten: Vec<Event<'static>> = rewrite(
+            events,
+            |event: Event<'static>, writer: &mut Writer<'static>| {
+                if let event @ Event::Text(_) = event {
+                    writer.push(event);
+                }
+            },
+        )
+        .collect();
+
+        assert_eq!(
+            rewritten,
+            vec![
+                Event::Text("This is some text.".into()),
+                Event::Text("This is some more text.".into()),
+            ]
+        );
+    }
+}


### PR DESCRIPTION
The documentation for `Rewriter` suggests that it can choose to completely ignore events thereby removing them from the rewritten stream, specifically it says
```
This may mean ignoring it, mutating it, or adding new events to the [`Writer`]'s buffer.
```

I am admittedly not completely sure that I fully understand how things are supposed to work, but the implementation of `Rewritten` does not currently seem to handle this case and seems to stop as soon as a `Rewrite` implementation does not push any events into the writer.

I tried to demonstrate this in the test case added by the first commit. The second commit tries to resolve this by effectively looping the `Iterator::next` implementation of `Rewritten` so that it continues with the next input event in case an output event was ignored completely. 