### PR TITLE
update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,11 +14,10 @@ exclude = ["benches/adventures.michaelfbryan.com"]
 travis-ci = { repository = "Michael-F-Bryan/markedit", branch = "master" }
 
 [dependencies]
-pulldown-cmark = "0.7"
-
+pulldown-cmark = "0.9.2"
 [dev-dependencies]
-criterion = "0.3"
-glob = "0.3.0"
+criterion = "0.4"
+glob = "0.3"
 
 [[bench]]
 name = "benchmarks"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "markedit"
-version = "0.3.1-alpha.0"
+version = "0.4.0"
 authors = ["Michael Bryan <michaelfbryan@gmail.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2018"

--- a/benches/benchmarks.rs
+++ b/benches/benchmarks.rs
@@ -2,7 +2,7 @@ use criterion::{
     criterion_group, criterion_main, BenchmarkId, Criterion, Throughput,
 };
 use markedit::{Heading, Matcher, Rewriter, Writer};
-use pulldown_cmark::Event;
+use pulldown_cmark::{Event, HeadingLevel};
 use std::path::{Path, PathBuf};
 
 fn known_markdown_files() -> impl Iterator<Item = PathBuf> {
@@ -54,7 +54,7 @@ pub fn rewriting(c: &mut Criterion) {
                     b.iter(|| {
                         markedit::insert_markdown_before(
                             "## Sub-Heading",
-                            Heading::with_level(2).falling_edge(),
+                            Heading::with_level(pulldown_cmark::HeadingLevel::H2).falling_edge(),
                         )
                         .rewrite(markedit::parse(src))
                         .count()
@@ -80,7 +80,7 @@ pub fn rewriting(c: &mut Criterion) {
                 &src,
                 |b, src| {
                     b.iter(|| {
-                        upper_case_header_text(2)
+                        upper_case_header_text(HeadingLevel::H2)
                             .rewrite(markedit::parse(src))
                             .count()
                     })
@@ -89,7 +89,7 @@ pub fn rewriting(c: &mut Criterion) {
     }
 }
 
-fn upper_case_header_text<'src>(level: u32) -> impl Rewriter<'src> {
+fn upper_case_header_text<'src>(level: HeadingLevel) -> impl Rewriter<'src> {
     let mut matcher = Heading::with_level(level);
 
     move |ev: Event<'src>, writer: &mut Writer<'src>| {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,13 +16,13 @@
 //! markdown after a heading.
 //!
 //! ```rust
-//! use pulldown_cmark::{Event, Tag};
+//! use pulldown_cmark::{Event, Tag, HeadingLevel};
 //! use markedit::{Matcher, Heading};
 //!
 //! let src = "# Heading\n Some text\n some more text \n\n # Another Heading";
 //!
 //! // first we need to construct our predicate
-//! let matcher = Heading::with_level(1).falling_edge();
+//! let matcher = Heading::with_level(HeadingLevel::H1).falling_edge();
 //!
 //! // we also need a rewriting rule
 //! let rule = markedit::insert_markdown_before("## Sub-Heading", matcher);
@@ -36,9 +36,9 @@
 //! // the heading before we want to insert
 //! assert_eq!(mutated[1], Event::Text("Heading".into()));
 //! // our inserted tags
-//! assert_eq!(mutated[3], Event::Start(Tag::Heading(2)));
+//! assert_eq!(mutated[3], Event::Start(Tag::Heading(HeadingLevel::H2, None, vec![])));
 //! assert_eq!(mutated[4], Event::Text("Sub-Heading".into()));
-//! assert_eq!(mutated[5], Event::End(Tag::Heading(2)));
+//! assert_eq!(mutated[5], Event::End(Tag::Heading(HeadingLevel::H2, None, vec![])));
 //! // "Some text" is the line after
 //! assert_eq!(mutated[7], Event::Text("Some text".into()));
 //! ```

--- a/src/matchers/mod.rs
+++ b/src/matchers/mod.rs
@@ -45,7 +45,7 @@ pub trait Matcher {
             .position(|ev| self.matches_event(ev.borrow()))
     }
 
-    /// Checks whether this [`Matcher`] would match anything in a stream of
+    /// Checks whether this [`Matcher`] matches anything in a stream of
     /// [`Event`]s.
     ///
     /// # Examples

--- a/src/rewriters/mod.rs
+++ b/src/rewriters/mod.rs
@@ -5,7 +5,7 @@ pub use rewritten::{rewrite, Rewritten};
 pub use writer::Writer;
 
 use crate::Matcher;
-use pulldown_cmark::{CodeBlockKind, CowStr, Event, Tag};
+use pulldown_cmark::{CowStr, Event};
 
 /// Something which can rewrite events.
 pub trait Rewriter<'src> {
@@ -58,17 +58,14 @@ where
 /// // if everything went to plan, the output should contain "Second Heading"
 /// assert!(markedit::exact_text("Second Heading").is_in(&rewritten));
 /// ```
-pub fn insert_markdown_before<'src, M, S>(
-    markdown_text: S,
+pub fn insert_markdown_before<'src, M>(
+    markdown_text: &'src str,
     matcher: M,
 ) -> impl Rewriter<'src> + 'src
 where
     M: Matcher + 'src,
-    S: AsRef<str> + 'src,
 {
-    let events = crate::parse(markdown_text.as_ref())
-        .map(owned_event)
-        .collect();
+    let events = crate::parse(markdown_text).collect();
     insert_before(events, matcher)
 }
 
@@ -109,60 +106,5 @@ where
             writer.push(Event::Text(text));
         },
         _ => writer.push(ev),
-    }
-}
-
-fn owned_event(ev: Event<'_>) -> Event<'static> {
-    match ev {
-        Event::Start(tag) => Event::Start(owned_tag(tag)),
-        Event::End(tag) => Event::End(owned_tag(tag)),
-        Event::Text(s) => Event::Text(owned_cow_str(s)),
-        Event::Code(s) => Event::Code(owned_cow_str(s)),
-        Event::Html(s) => Event::Html(owned_cow_str(s)),
-        Event::FootnoteReference(s) => {
-            Event::FootnoteReference(owned_cow_str(s))
-        },
-        Event::SoftBreak => Event::SoftBreak,
-        Event::HardBreak => Event::HardBreak,
-        Event::Rule => Event::Rule,
-        Event::TaskListMarker(t) => Event::TaskListMarker(t),
-    }
-}
-
-fn owned_cow_str(s: CowStr<'_>) -> CowStr<'static> {
-    match s {
-        CowStr::Borrowed(_) => CowStr::from(s.into_string()),
-        CowStr::Boxed(boxed) => CowStr::Boxed(boxed),
-        CowStr::Inlined(inlined) => CowStr::Inlined(inlined),
-    }
-}
-
-fn owned_tag(tag: Tag<'_>) -> Tag<'static> {
-    match tag {
-        Tag::Paragraph => Tag::Paragraph,
-        Tag::Heading(h) => Tag::Heading(h),
-        Tag::BlockQuote => Tag::BlockQuote,
-        Tag::CodeBlock(CodeBlockKind::Indented) => {
-            Tag::CodeBlock(CodeBlockKind::Indented)
-        },
-        Tag::CodeBlock(CodeBlockKind::Fenced(s)) => {
-            Tag::CodeBlock(CodeBlockKind::Fenced(owned_cow_str(s)))
-        },
-        Tag::List(u) => Tag::List(u),
-        Tag::Item => Tag::Item,
-        Tag::FootnoteDefinition(s) => Tag::FootnoteDefinition(owned_cow_str(s)),
-        Tag::Table(alignment) => Tag::Table(alignment),
-        Tag::TableHead => Tag::TableHead,
-        Tag::TableRow => Tag::TableRow,
-        Tag::TableCell => Tag::TableCell,
-        Tag::Emphasis => Tag::Emphasis,
-        Tag::Strong => Tag::Strong,
-        Tag::Strikethrough => Tag::Strikethrough,
-        Tag::Link(t, url, title) => {
-            Tag::Link(t, owned_cow_str(url), owned_cow_str(title))
-        },
-        Tag::Image(t, url, alt) => {
-            Tag::Image(t, owned_cow_str(url), owned_cow_str(alt))
-        },
     }
 }

--- a/src/rewriters/mod.rs
+++ b/src/rewriters/mod.rs
@@ -58,14 +58,15 @@ where
 /// // if everything went to plan, the output should contain "Second Heading"
 /// assert!(markedit::exact_text("Second Heading").is_in(&rewritten));
 /// ```
-pub fn insert_markdown_before<'src, M>(
-    markdown_text: &'src str,
+pub fn insert_markdown_before<'src, M, S>(
+    markdown_text: S,
     matcher: M,
 ) -> impl Rewriter<'src> + 'src
 where
     M: Matcher + 'src,
+    S: Into<&'src str>,
 {
-    let events = crate::parse(markdown_text).collect();
+    let events = crate::parse(markdown_text.into()).collect();
     insert_before(events, matcher)
 }
 

--- a/src/rewriters/rewritten.rs
+++ b/src/rewriters/rewritten.rs
@@ -68,7 +68,7 @@ mod tests {
         let events = vec![
             Event::Start(Tag::Paragraph),
             Event::Text("This is some text.".into()),
-            Event::Start(Tag::Heading(2)),
+            Event::Start(Tag::Heading(pulldown_cmark::HeadingLevel::H2, None, vec![])),
             Event::Text("This is some more text.".into()),
         ];
 


### PR DESCRIPTION
`pulldown-cmark-to-cmark` uses the latest version, and using the crate as-is causes compile errors probably due to the types arising from two different versions of the crate?